### PR TITLE
chore: add post-upgrade tasks for npm dependency update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,12 @@
     },
     {
       "groupName": "npm",
-      "matchManagers": ["npm"]
+      "matchManagers": ["npm"],
+      "postUpgradeTasks": {
+        "commands": ["npm run bundle"],
+        "fileFilters": ["dist/**"],
+        "executionMode": "update"
+      }
     }
   ]
 }


### PR DESCRIPTION
This pull request includes a change to the `renovate.json` configuration file to add post-upgrade tasks for the npm manager.

Configuration update:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L14-R19): Added `postUpgradeTasks` for the npm manager to run `npm run bundle` and filter files in the `dist` directory after upgrades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `postUpgradeTasks` option in configuration for enhanced automation after package upgrades, streamlining workflow.
  
- **Improvements**
	- Added specific commands to execute build steps automatically following updates, reducing manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->